### PR TITLE
fix: update monit link to official bitbucket repository

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@
                 <ul class="resources-list">
                     <li><a href="https://github.com/denyhosts/denyhosts">DenyHosts</a> - SSH server access control and monitoring</li>
                     <li><a href="https://github.com/logwatch/logwatch">Logwatch</a> - Customizable log analysis system</li>
-                    <li><a href="https://github.com/monit/monit">Monit</a> - Utility for monitoring services on a Unix system</li>
+                    <li><a href="https://bitbucket.org/tildeslash/monit/src/master/">Monit</a> - Utility for monitoring services on a Unix system</li>
                 </ul>
 
                 <div class="integration-note">


### PR DESCRIPTION
Monit may have existed on Github at one point, but it no longer exists. It looks like they migrated to bitbucket, so I've updated the link under `additional resources` accordingly. This is a drive-by commit created via Github on the web, so I didn't run any linting or tests for the changes.

## Checklist

- [X] I have ensured my pull request is not behind the main or master branch of the original repository.
- [X] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [ ] I have written a commit message that passes commitlint linting.
- [ ] I have ensured that my code changes pass linting tests.
- [ ] I have ensured that my code changes pass unit tests.
- [X] I have described my pull request and the reasons for code changes along with context if necessary.
